### PR TITLE
Ensure NPM is installed too

### DIFF
--- a/reactive/node.py
+++ b/reactive/node.py
@@ -30,7 +30,7 @@ def install_nodejs():
     kv.set('nodejs.url', config.get('install_sources'))
     kv.set('nodejs.key', config.get('install_keys'))
 
-    apt.queue_install(['nodejs'])
+    apt.queue_install(['nodejs', 'npm'])
 
 
 @when('apt.installed.nodejs')


### PR DESCRIPTION
With Xenial onwards NPM is a separate package to NodeJS (well, it's not a dependency so you can't just install NodeJS and expect it to be available), so we need to request both are installed.
