### PR TITLE
Add nodejs-legacy to installed packages

### DIFF
--- a/reactive/node.py
+++ b/reactive/node.py
@@ -30,7 +30,7 @@ def install_nodejs():
     kv.set('nodejs.url', config.get('install_sources'))
     kv.set('nodejs.key', config.get('install_keys'))
 
-    apt.queue_install(['nodejs', 'npm'])
+    apt.queue_install(['nodejs', 'npm', 'nodejs-legacy'])
 
 
 @when('apt.installed.nodejs')


### PR DESCRIPTION
A **slightly** more controversial change in adding "nodejs-legacy" which will symlink "/usr/bin/node" to "/usr/bin/nodejs", this is because 90% of NPM modules ship with their bin scripts pointing to `/usr/bin/env node`.
I reckon this is a reasonable change given:
  a) It's highly unlikely anyone wants to deploy the `node` packet radio app into a unit, alongside their NodeJS app, using Juju.
  b) I can't think of any situation (other than the extreme edge case of hulk smashing onto a developer VM) were the unit is not confined using a VM or LXC.
  c) In jessie and 16.04 the `command-not-found` package will suggest `nodejs-legacy` if you try `node`.
